### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/fernforestgames/mcp-server-godot/security/code-scanning/2](https://github.com/fernforestgames/mcp-server-godot/security/code-scanning/2)

The best way to fix this problem is to explicitly set the permissions for the `test` job to the minimum required. For typical CI tasks like checkout, node setup, dependency installation, build, and lint, those steps only need read access to repository contents. Thus, add a `permissions` block to the `test` job specifying `contents: read`. Make this change directly under the `test:` job in `.github/workflows/ci.yml`, after the `runs-on:` line, matching the structure already seen in the `publish` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
